### PR TITLE
Add line chart page implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm run build -- --configuration development
 
 ### 基本チャート
 - [x] Bar Chart (棒グラフ) - `client/src/app/charts/bar-chart/`
-- [ ] Line Chart (折れ線グラフ)
+- [x] Line Chart (折れ線グラフ) - `client/src/app/charts/line-chart/`
 - [ ] Pie Chart (円グラフ)
 - [ ] Scatter Chart (散布図)
 - [ ] Area Chart (エリアチャート)

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -8,5 +8,9 @@ export const routes: Routes = [
   {
     path: 'bar-chart',
     loadComponent: () => import('./charts/bar-chart/bar-chart.component').then(m => m.BarChartComponent)
+  },
+  {
+    path: 'line-chart',
+    loadComponent: () => import('./charts/line-chart/line-chart.component').then(m => m.LineChartComponent)
   }
 ];

--- a/client/src/app/charts/line-chart/line-chart.component.ts
+++ b/client/src/app/charts/line-chart/line-chart.component.ts
@@ -1,0 +1,94 @@
+import { Component, ChangeDetectionStrategy, OnInit, computed, signal } from '@angular/core';
+import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
+import type { EChartsOption } from 'echarts';
+
+@Component({
+  selector: 'app-line-chart',
+  imports: [NgxEchartsModule],
+  providers: [
+    {
+      provide: NGX_ECHARTS_CONFIG,
+      useFactory: () => ({ echarts: () => import('echarts') })
+    }
+  ],
+  template: `
+    <div class="chart-container">
+      <h2>Line Chart Sample</h2>
+      <div echarts [options]="chartOptions()" class="chart"></div>
+    </div>
+  `,
+  styles: [`
+    .chart-container {
+      padding: 20px;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    h2 {
+      color: #333;
+      margin-bottom: 20px;
+    }
+
+    .chart {
+      height: 500px;
+      width: 100%;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class LineChartComponent implements OnInit {
+  private readonly seriesData = signal({
+    categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
+    values: [820, 932, 901, 934, 1290, 1330, 1320]
+  });
+
+  protected readonly chartOptions = computed<EChartsOption>(() => ({
+    title: {
+      text: 'Monthly Revenue Trend',
+      left: 'center'
+    },
+    tooltip: {
+      trigger: 'axis'
+    },
+    grid: {
+      left: '3%',
+      right: '4%',
+      bottom: '3%',
+      containLabel: true
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: this.seriesData().categories
+    },
+    yAxis: {
+      type: 'value'
+    },
+    series: [
+      {
+        name: 'Revenue',
+        type: 'line',
+        smooth: true,
+        symbol: 'circle',
+        symbolSize: 10,
+        lineStyle: {
+          width: 4
+        },
+        areaStyle: {
+          color: 'rgba(84, 112, 198, 0.2)'
+        },
+        emphasis: {
+          focus: 'series'
+        },
+        data: this.seriesData().values
+      }
+    ]
+  }));
+
+  ngOnInit(): void {
+    console.log('Line chart component initialized');
+  }
+}

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -16,11 +16,11 @@ import { RouterLink } from '@angular/router';
           <p>Basic bar chart with weekly sales data</p>
         </a>
 
-        <div class="chart-card placeholder">
+        <a routerLink="/line-chart" class="chart-card">
           <div class="chart-icon">📈</div>
           <h3>Line Chart</h3>
-          <p>Coming soon</p>
-        </div>
+          <p>Smooth line chart with monthly revenue trend</p>
+        </a>
 
         <div class="chart-card placeholder">
           <div class="chart-icon">🥧</div>


### PR DESCRIPTION
## Summary
- add a standalone line chart component showcasing a smooth revenue trend example
- expose the line chart route and update the home page card to link to it
- document the new chart availability in the project README

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d9513184308323824948efde0e0f46