### PR TITLE
Ensure components inherit full layout size

### DIFF
--- a/client/src/app/app.scss
+++ b/client/src/app/app.scss
@@ -1,5 +1,7 @@
 :host {
   display: block;
+  width: 100%;
+  height: 100%;
   min-height: 100vh;
   background: #f5f5f5;
 }

--- a/client/src/app/charts/area-chart/area-chart.component.scss
+++ b/client/src/app/charts/area-chart/area-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/charts/bar-chart/bar-chart.component.scss
+++ b/client/src/app/charts/bar-chart/bar-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/charts/line-chart/line-chart.component.scss
+++ b/client/src/app/charts/line-chart/line-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/charts/pie-chart/pie-chart.component.scss
+++ b/client/src/app/charts/pie-chart/pie-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/charts/radar-chart/radar-chart.component.scss
+++ b/client/src/app/charts/radar-chart/radar-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/charts/scatter-chart/scatter-chart.component.scss
+++ b/client/src/app/charts/scatter-chart/scatter-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .chart-container {
   padding: 20px;
-  height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/app/home/home.component.scss
+++ b/client/src/app/home/home.component.scss
@@ -1,3 +1,9 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .home-container {
   padding: 40px 20px;
   max-width: 1200px;

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -1,1 +1,20 @@
 /* You can add global styles to this file, and also import other style files */
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+app-root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+}


### PR DESCRIPTION
## Summary
- set the app root and every component host to span 100% width and height
- rely on percentage-based sizing within chart containers instead of viewport units so nested layouts inherit dimensions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95d238bf48323b2455657ade1c854