### PR TITLE
feat: localize chart headings for japanese audience

### DIFF
--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -1,10 +1,14 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { providePrimeNG } from 'primeng/config';
 import Aura from '@primeuix/themes/aura';
+import { registerLocaleData } from '@angular/common';
+import localeJa from '@angular/common/locales/ja';
 
 import { routes } from './app.routes';
+
+registerLocaleData(localeJa);
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -16,6 +20,7 @@ export const appConfig: ApplicationConfig = {
       theme: {
         preset: Aura
       }
-    })
+    }),
+    { provide: LOCALE_ID, useValue: 'ja-JP' }
   ]
 };

--- a/client/src/app/charts/area-chart/area-chart.component.html
+++ b/client/src/app/charts/area-chart/area-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Area Chart Sample</h2>
+  <h2>面グラフのサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/area-chart/area-chart.component.ts
+++ b/client/src/app/charts/area-chart/area-chart.component.ts
@@ -17,14 +17,14 @@ import type { EChartsOption } from 'echarts';
 })
 export class AreaChartComponent {
   private readonly trafficData = signal({
-    categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    categories: ['月', '火', '水', '木', '金', '土', '日'],
     desktop: [320, 332, 301, 334, 390, 330, 320],
     mobile: [120, 132, 101, 134, 90, 230, 210]
   });
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Weekly Website Traffic',
+      text: '週間ウェブサイトトラフィック',
       left: 'center'
     },
     tooltip: {
@@ -37,12 +37,14 @@ export class AreaChartComponent {
       }
     },
     legend: {
-      data: ['Desktop', 'Mobile'],
+      data: ['デスクトップ', 'モバイル'],
       bottom: 10
     },
     toolbox: {
       feature: {
-        saveAsImage: {}
+        saveAsImage: {
+          title: '画像として保存'
+        }
       }
     },
     grid: {
@@ -65,7 +67,7 @@ export class AreaChartComponent {
     ],
     series: [
       {
-        name: 'Desktop',
+        name: 'デスクトップ',
         type: 'line',
         smooth: true,
         areaStyle: {},
@@ -75,7 +77,7 @@ export class AreaChartComponent {
         data: this.trafficData().desktop
       },
       {
-        name: 'Mobile',
+        name: 'モバイル',
         type: 'line',
         smooth: true,
         areaStyle: {},

--- a/client/src/app/charts/bar-chart/bar-chart.component.html
+++ b/client/src/app/charts/bar-chart/bar-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Bar Chart Sample</h2>
+  <h2>棒グラフのサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/bar-chart/bar-chart.component.ts
+++ b/client/src/app/charts/bar-chart/bar-chart.component.ts
@@ -17,13 +17,13 @@ import type { EChartsOption } from 'echarts';
 })
 export class BarChartComponent {
   private readonly data = signal({
-    categories: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    categories: ['月', '火', '水', '木', '金', '土', '日'],
     values: [120, 200, 150, 80, 70, 110, 130]
   });
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Weekly Sales Data',
+      text: '週間売上データ',
       left: 'center'
     },
     tooltip: {
@@ -41,7 +41,7 @@ export class BarChartComponent {
     },
     series: [
       {
-        name: 'Sales',
+        name: '売上',
         data: this.data().values,
         type: 'bar',
         itemStyle: {

--- a/client/src/app/charts/line-chart/line-chart.component.html
+++ b/client/src/app/charts/line-chart/line-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Line Chart Sample</h2>
+  <h2>折れ線グラフのサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/line-chart/line-chart.component.ts
+++ b/client/src/app/charts/line-chart/line-chart.component.ts
@@ -17,13 +17,13 @@ import type { EChartsOption } from 'echarts';
 })
 export class LineChartComponent {
   private readonly seriesData = signal({
-    categories: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul'],
+    categories: ['1月', '2月', '3月', '4月', '5月', '6月', '7月'],
     values: [820, 932, 901, 934, 1290, 1330, 1320]
   });
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Monthly Revenue Trend',
+      text: '月次売上推移',
       left: 'center'
     },
     tooltip: {
@@ -45,7 +45,7 @@ export class LineChartComponent {
     },
     series: [
       {
-        name: 'Revenue',
+        name: '売上高',
         type: 'line',
         smooth: true,
         symbol: 'circle',

--- a/client/src/app/charts/pie-chart/pie-chart.component.html
+++ b/client/src/app/charts/pie-chart/pie-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Pie Chart Sample</h2>
+  <h2>円グラフのサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/pie-chart/pie-chart.component.ts
+++ b/client/src/app/charts/pie-chart/pie-chart.component.ts
@@ -17,16 +17,16 @@ import type { EChartsOption } from 'echarts';
 })
 export class PieChartComponent {
   private readonly salesShare = signal([
-    { value: 1048, name: 'Electronics' },
-    { value: 735, name: 'Apparel' },
-    { value: 580, name: 'Home Goods' },
-    { value: 484, name: 'Sports' },
-    { value: 300, name: 'Books' }
+    { value: 1048, name: '家電' },
+    { value: 735, name: 'アパレル' },
+    { value: 580, name: 'ホーム用品' },
+    { value: 484, name: 'スポーツ' },
+    { value: 300, name: '書籍' }
   ]);
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Sales Distribution by Category',
+      text: 'カテゴリ別売上構成',
       left: 'center'
     },
     tooltip: {
@@ -38,7 +38,7 @@ export class PieChartComponent {
     },
     series: [
       {
-        name: 'Sales Share',
+        name: '売上構成',
         type: 'pie',
         radius: '60%',
         center: ['50%', '60%'],

--- a/client/src/app/charts/radar-chart/radar-chart.component.html
+++ b/client/src/app/charts/radar-chart/radar-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Radar Chart Sample</h2>
+  <h2>レーダーチャートのサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/radar-chart/radar-chart.component.ts
+++ b/client/src/app/charts/radar-chart/radar-chart.component.ts
@@ -18,12 +18,12 @@ import type { EChartsOption } from 'echarts';
 export class RadarChartComponent {
   private readonly skillScores = signal({
     indicators: [
-      { name: 'Communication', max: 100 },
-      { name: 'Problem Solving', max: 100 },
-      { name: 'Technical Skills', max: 100 },
-      { name: 'Teamwork', max: 100 },
-      { name: 'Leadership', max: 100 },
-      { name: 'Creativity', max: 100 }
+      { name: 'コミュニケーション', max: 100 },
+      { name: '問題解決力', max: 100 },
+      { name: '技術力', max: 100 },
+      { name: 'チームワーク', max: 100 },
+      { name: 'リーダーシップ', max: 100 },
+      { name: '創造性', max: 100 }
     ],
     candidateA: [85, 90, 95, 80, 70, 88],
     candidateB: [75, 80, 88, 85, 65, 92]
@@ -31,11 +31,11 @@ export class RadarChartComponent {
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Candidate Skill Comparison',
+      text: '候補者のスキル比較',
       left: 'center'
     },
     legend: {
-      data: ['Candidate A', 'Candidate B'],
+      data: ['候補者A', '候補者B'],
       bottom: 10
     },
     tooltip: {},
@@ -49,11 +49,11 @@ export class RadarChartComponent {
         data: [
           {
             value: this.skillScores().candidateA,
-            name: 'Candidate A'
+            name: '候補者A'
           },
           {
             value: this.skillScores().candidateB,
-            name: 'Candidate B'
+            name: '候補者B'
           }
         ]
       }

--- a/client/src/app/charts/scatter-chart/scatter-chart.component.html
+++ b/client/src/app/charts/scatter-chart/scatter-chart.component.html
@@ -1,4 +1,4 @@
 <div class="chart-container">
-  <h2>Scatter Chart Sample</h2>
+  <h2>散布図のサンプル</h2>
   <div echarts [options]="chartOptions()" class="chart"></div>
 </div>

--- a/client/src/app/charts/scatter-chart/scatter-chart.component.ts
+++ b/client/src/app/charts/scatter-chart/scatter-chart.component.ts
@@ -40,7 +40,7 @@ export class ScatterChartComponent {
 
   protected readonly chartOptions = computed<EChartsOption>(() => ({
     title: {
-      text: 'Study Hours vs. Exam Score',
+      text: '学習時間と試験スコア',
       left: 'center'
     },
     tooltip: {
@@ -48,15 +48,15 @@ export class ScatterChartComponent {
     },
     xAxis: {
       type: 'value',
-      name: 'Study Hours'
+      name: '学習時間（時間）'
     },
     yAxis: {
       type: 'value',
-      name: 'Exam Score'
+      name: '試験スコア'
     },
     series: [
       {
-        name: 'Students',
+        name: '受験者',
         type: 'scatter',
         symbolSize: 16,
         emphasis: {
@@ -68,7 +68,7 @@ export class ScatterChartComponent {
         data: this.studyData().hours
       },
       {
-        name: 'Trend Line',
+        name: 'トレンドライン',
         type: 'line',
         showSymbol: false,
         smooth: true,

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -1,42 +1,42 @@
 <div class="home-container">
-  <h1>ECharts Sample Gallery</h1>
-  <p class="description">Click on a chart type to see the example</p>
+  <h1>ECharts サンプルギャラリー</h1>
+  <p class="description">表示したいチャートタイプを選択してください</p>
 
   <div class="chart-grid">
     <a routerLink="/bar-chart" class="chart-card">
       <div class="chart-icon">📊</div>
-      <h3>Bar Chart</h3>
-      <p>Basic bar chart with weekly sales data</p>
+      <h3>棒グラフ</h3>
+      <p>週間売上データを表示する基本的な棒グラフです</p>
     </a>
 
     <a routerLink="/line-chart" class="chart-card">
       <div class="chart-icon">📈</div>
-      <h3>Line Chart</h3>
-      <p>Smooth line chart with monthly revenue trend</p>
+      <h3>折れ線グラフ</h3>
+      <p>月次売上の推移を滑らかな線で表示します</p>
     </a>
 
     <a routerLink="/pie-chart" class="chart-card">
       <div class="chart-icon">🥧</div>
-      <h3>Pie Chart</h3>
-      <p>Category-based pie chart showing sales distribution</p>
+      <h3>円グラフ</h3>
+      <p>カテゴリ別の売上構成を示す円グラフです</p>
     </a>
 
     <a routerLink="/scatter-chart" class="chart-card">
       <div class="chart-icon">🎯</div>
-      <h3>Scatter Chart</h3>
-      <p>Scatter plot visualizing study hours and exam scores</p>
+      <h3>散布図</h3>
+      <p>学習時間と試験スコアの関係を可視化します</p>
     </a>
 
     <a routerLink="/area-chart" class="chart-card">
       <div class="chart-icon">🌄</div>
-      <h3>Area Chart</h3>
-      <p>Stacked area chart comparing desktop and mobile traffic</p>
+      <h3>面グラフ</h3>
+      <p>デスクトップとモバイルのトラフィックを積み上げ面グラフで比較します</p>
     </a>
 
     <a routerLink="/radar-chart" class="chart-card">
       <div class="chart-icon">🕸️</div>
-      <h3>Radar Chart</h3>
-      <p>Radar chart comparing candidate skill sets</p>
+      <h3>レーダーチャート</h3>
+      <p>候補者のスキルセットをレーダーチャートで比較します</p>
     </a>
   </div>
 </div>

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,8 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja" translate="no">
 <head>
   <meta charset="utf-8">
-  <title>Client</title>
+  <meta http-equiv="Content-Language" content="ja">
+  <meta name="google" content="notranslate">
+  <title>ECharts サンプルギャラリー</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- replace chart detail headings and home navigation card titles with Japanese labels for the intended audience
- mark the document language as Japanese and add notranslate hints to prevent automatic translation mishaps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0ff049948323a00878c377bc443f