### PR TITLE
Cache time series datasets for line chart component

### DIFF
--- a/client/src/app/charts/line-chart-timeseries/line-chart-timeseries.component.ts
+++ b/client/src/app/charts/line-chart-timeseries/line-chart-timeseries.component.ts
@@ -195,6 +195,8 @@ export class LineChartTimeseriesComponent {
   showMaxMin = signal(true);
   showOutliers = signal(false);
 
+  private readonly datasets = this.generateTimeSeriesData();
+
   // Generate time series data
   private generateTimeSeriesData() {
     const datasets = {
@@ -327,7 +329,7 @@ export class LineChartTimeseriesComponent {
   }
 
   getDatasetInfo() {
-    const data = this.generateTimeSeriesData()[this.currentDataset()];
+    const data = this.datasets[this.currentDataset()];
     const pointCount = data.data.length;
     const firstDate = data.data[0]?.time;
     const lastDate = data.data[data.data.length - 1]?.time;
@@ -363,7 +365,7 @@ export class LineChartTimeseriesComponent {
   }
 
   protected readonly chartOptions = computed(() => {
-    const dataset = this.generateTimeSeriesData()[this.currentDataset()];
+    const dataset = this.datasets[this.currentDataset()];
     const series: any[] = [];
 
     if (this.currentDataset() === 'stock' || this.currentDataset() === 'sales') {


### PR DESCRIPTION
## Summary
- cache the time series datasets when the component is created so data is generated only once
- update chart options and dataset metadata lookups to reuse the cached datasets instead of regenerating

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da52b332e08323af2cb76fc2c3b8c1