### PR TITLE
Add Excel upload support to Chart Editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "primeng": "^20.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
+        "xlsx": "^0.18.5",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
@@ -27,6 +28,7 @@
         "@angular/cli": "^20.3.3",
         "@angular/compiler-cli": "^20.3.0",
         "@types/jasmine": "~5.1.0",
+        "@types/xlsx": "^0.0.36",
         "jasmine-core": "~5.9.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "primeng": "^20.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
+    "xlsx": "^0.18.5",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@angular/cli": "^20.3.3",
     "@angular/compiler-cli": "^20.3.0",
     "@types/jasmine": "~5.1.0",
+    "@types/xlsx": "^0.0.36",
     "jasmine-core": "~5.9.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/client/src/app/chart-editor/chart-editor.component.html
+++ b/client/src/app/chart-editor/chart-editor.component.html
@@ -1,25 +1,25 @@
 <div class="chart-editor-container">
   <h1>Chart Editor</h1>
 
-  <!-- CSV Upload Section -->
+  <!-- CSV/Excel Upload Section -->
   @if (!csvData()) {
     <div class="upload-section">
       <div class="upload-card">
-        <h2>Upload CSV File</h2>
+        <h2>Upload CSV/Excel File</h2>
         <p class="upload-description">
-          CSVファイルをアップロードしてください。1行目はヘッダー、2行目以降がデータとして扱われます。
+          CSV/Excelファイルをアップロードしてください。1行目はヘッダー、2行目以降がデータとして扱われます。
         </p>
         <div class="file-input-wrapper">
           <input
             type="file"
-            accept=".csv"
+            accept=".csv, .xlsx, .xls"
             (change)="onFileSelected($event)"
             id="csvFileInput"
             class="file-input"
           />
           <label for="csvFileInput" class="file-input-label">
             <span class="upload-icon">📁</span>
-            <span>Choose CSV File</span>
+            <span>Choose CSV/Excel File</span>
           </label>
         </div>
       </div>

--- a/client/src/app/chart-editor/chart-editor.component.ts
+++ b/client/src/app/chart-editor/chart-editor.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
+import * as XLSX from 'xlsx';
 
 interface CsvData {
   headers: string[];
@@ -111,12 +112,33 @@ export class ChartEditorComponent {
 
     if (!file) return;
 
+    const extension = file.name.split('.').pop()?.toLowerCase();
     const reader = new FileReader();
-    reader.onload = (e: ProgressEvent<FileReader>) => {
-      const text = e.target?.result as string;
-      this.parseCsv(text);
-    };
-    reader.readAsText(file);
+
+    switch (extension) {
+      case 'xlsx':
+      case 'xls':
+        reader.onload = (e: ProgressEvent<FileReader>) => {
+          const result = e.target?.result;
+          if (!result) {
+            alert('ファイルの読み込みに失敗しました');
+            return;
+          }
+          this.parseExcel(result as ArrayBuffer);
+        };
+        reader.readAsArrayBuffer(file);
+        break;
+      case 'csv':
+      case undefined:
+        reader.onload = (e: ProgressEvent<FileReader>) => {
+          const text = e.target?.result as string;
+          this.parseCsv(text);
+        };
+        reader.readAsText(file);
+        break;
+      default:
+        alert('対応していないファイル形式です。CSVまたはExcelファイルをアップロードしてください。');
+    }
   }
 
   private parseCsv(text: string): void {
@@ -131,10 +153,7 @@ export class ChartEditorComponent {
     const rows = lines.slice(1).map(line => this.parseCsvLine(line));
 
     this.csvData.set({ headers, rows });
-
-    // デフォルトで最初の列をX軸、2列目をY軸に設定
-    this.selectedXAxis.set(0);
-    this.selectedYAxis.set(headers.length > 1 ? [1] : []);
+    this.setDefaultSelections(headers);
   }
 
   private parseCsvLine(line: string): string[] {
@@ -170,5 +189,60 @@ export class ChartEditorComponent {
 
   isYAxisSelected(index: number): boolean {
     return this.selectedYAxis().includes(index);
+  }
+
+  private parseExcel(buffer: ArrayBuffer): void {
+    const workbook = XLSX.read(buffer, { type: 'array' });
+
+    const firstSheetName = workbook.SheetNames[0];
+    if (!firstSheetName) {
+      alert('Excelファイルには少なくとも2行（ヘッダー + データ）が必要です');
+      return;
+    }
+
+    const worksheet = workbook.Sheets[firstSheetName];
+    const sheetData = XLSX.utils.sheet_to_json<(string | number | boolean | null)[]>(worksheet, {
+      header: 1,
+      raw: false
+    });
+
+    if (!sheetData || sheetData.length < 2) {
+      alert('Excelファイルには少なくとも2行（ヘッダー + データ）が必要です');
+      return;
+    }
+
+    const [headerRow, ...dataRows] = sheetData;
+    const headers = headerRow.map(value => this.normalizeExcelCell(value));
+
+    const normalizedRows = dataRows
+      .map(row => this.normalizeExcelRow(row, headers.length))
+      .filter(row => row.some(cell => cell !== ''));
+
+    if (normalizedRows.length === 0) {
+      alert('Excelファイルには少なくとも2行（ヘッダー + データ）が必要です');
+      return;
+    }
+
+    this.csvData.set({ headers, rows: normalizedRows });
+    this.setDefaultSelections(headers);
+  }
+
+  private normalizeExcelRow(
+    row: (string | number | boolean | null)[] | undefined,
+    length: number
+  ): string[] {
+    const safeRow = row ?? [];
+    return Array.from({ length }, (_, index) => this.normalizeExcelCell(safeRow[index]));
+  }
+
+  private normalizeExcelCell(value: string | number | boolean | null): string {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value.trim();
+    return String(value);
+  }
+
+  private setDefaultSelections(headers: string[]): void {
+    this.selectedXAxis.set(0);
+    this.selectedYAxis.set(headers.length > 1 ? [1] : []);
   }
 }


### PR DESCRIPTION
## Summary
- add SheetJS as a dependency so the Chart Editor can parse Excel files alongside CSV uploads
- extend the file upload handler to branch between CSV and Excel parsing, including normalization and validation of Excel data
- refresh the upload UI copy to reference CSV/Excel files and allow selecting Excel extensions
- clarify the upload handler by using a switch statement to distinguish CSV versus Excel processing paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe036bc36c83239e447e120495e44c